### PR TITLE
Add support for vibe.d

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ d:
     - ldc
 os:
     - linux
+
+script:
+    - dub test --config=std
+    - dub test --config=vibed

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ HTTP requests library with goals:
 
 API docs: [Wiki](https://github.com/ikod/dlang-requests/wiki)
 
+###Library configurations###
+
+This library can either use the standard std.socket library or [vibe.d](http://vibed.org) for network IO. By default this library uses the standard std.socket configuration called *std*. To use vibe.d use the *vibed* configuration:
+
+```json
+"dependencies": {
+    "requests": "~>0.1.9"
+},
+"subConfigurations": {
+    "requests": "vibed"
+}
+```
+
 ###Make a simple Request###
 
 Making http/https/ftp request with dlang-requests is very simple. First of all install and import *requests* module:

--- a/dub.json
+++ b/dub.json
@@ -1,13 +1,24 @@
 {
-	"name": "requests",
-	"description": "http client library, inspired by python-requests",
-	"copyright": "Copyright © 2016, igor",
-	"authors": ["ikod"],
+    "name": "requests",
+    "description": "http client library, inspired by python-requests",
+    "copyright": "Copyright © 2016, igor",
+    "authors": ["ikod"],
     "license": "BSL-1.0",
-    "libs-posix": ["ssl", "crypto"],
-    "libs-windows": ["libssl32", "libeay32"],
-	"dependencies": {
-	},
+    "configurations": [
+        {
+            "name": "std",
+            "versions": ["sslLibs"],
+            "libs-posix": ["ssl", "crypto"],
+            "libs-windows": ["libssl32", "libeay32"]
+        },
+        {
+            "name": "vibed",
+            "versions": ["vibeD"],
+            "dependencies": {
+                "vibe-d": "~>0.7.29"
+            },
+        }
+    ],
     "buildTypes": {
         "docs": {
             "buildOptions": ["syntaxOnly"],

--- a/source/requests/base.d
+++ b/source/requests/base.d
@@ -5,8 +5,8 @@ import requests.utils;
 import requests.uri;
 
 public class RequestException: Exception {
-    this(string msg, string file = __FILE__, size_t line = __LINE__) @safe pure {
-        super(msg, file, line);
+    this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null) @safe pure nothrow {
+        super(msg, file, line, next);
     }
 }
 

--- a/source/requests/ftp.d
+++ b/source/requests/ftp.d
@@ -151,7 +151,7 @@ public struct FTPRequest {
         _response.finalURI = _uri;
 
         if ( !_controlChannel ) {
-            _controlChannel = new TCPSocketStream();
+            _controlChannel = new TCPStream();
             _controlChannel.connect(_uri.host, _uri.port, _timeout);
             response = serverResponse();
             _responseHistory ~= response;
@@ -210,7 +210,7 @@ public struct FTPRequest {
             return _response;
         }
 
-        auto dataStream = new TCPSocketStream();
+        auto dataStream = new TCPStream();
         scope (exit ) {
             if ( dataStream !is null ) {
                 dataStream.close();
@@ -267,7 +267,7 @@ public struct FTPRequest {
         _response.finalURI = _uri;
 
         if ( !_controlChannel ) {
-            _controlChannel = new TCPSocketStream();
+            _controlChannel = new TCPStream();
             _controlChannel.connect(_uri.host, _uri.port, _timeout);
             response = serverResponse();
             _responseHistory ~= response;
@@ -350,7 +350,7 @@ public struct FTPRequest {
             return _response;
         }
         
-        auto dataStream = new TCPSocketStream();
+        auto dataStream = new TCPStream();
         scope (exit ) {
             if ( dataStream !is null && !_response._receiveAsRange.activated ) {
                 dataStream.close();

--- a/source/requests/ftp.d
+++ b/source/requests/ftp.d
@@ -21,8 +21,8 @@ import requests.streams;
 import requests.base;
 
 public class FTPServerResponseError: Exception {
-    this(string msg, string file = __FILE__, size_t line = __LINE__) @safe pure {
-        super(msg, file, line);
+    this(string message, string file = __FILE__, size_t line = __LINE__, Throwable next = null) @safe pure nothrow {
+        super(message, file, line, next);
     }
 }
 

--- a/source/requests/ftp.d
+++ b/source/requests/ftp.d
@@ -6,7 +6,6 @@ import std.algorithm;
 import std.conv;
 import std.datetime;
 import std.format;
-import std.socket;
 import std.exception;
 import std.string;
 import std.range;
@@ -41,7 +40,7 @@ public struct FTPRequest {
         long          _maxContentLength = 5*1024*1024*1024;
         long          _contentLength = -1;
         long          _contentReceived;
-        SocketStream  _controlChannel;
+        NetworkStream _controlChannel;
         string[]      _responseHistory;
         FTPResponse   _response;
         bool          _useStreaming;
@@ -100,9 +99,9 @@ public struct FTPRequest {
     string serverResponse() {
         string res, buffer;
         immutable bufferLimit = 16*1024;
-        _controlChannel.so.setOption(SocketOptionLevel.SOCKET, SocketOption.RCVTIMEO, _timeout);
+        _controlChannel.readTimeout = _timeout;
         scope(exit) {
-            _controlChannel.so.setOption(SocketOptionLevel.SOCKET, SocketOption.RCVTIMEO, 0.seconds);
+            _controlChannel.readTimeout = 0.seconds;
         }
         auto b = new ubyte[_bufferSize];
         while ( buffer.length < bufferLimit ) {

--- a/source/requests/http.d
+++ b/source/requests/http.d
@@ -701,10 +701,10 @@ public struct HTTPRequest {
             }
             final switch (uri.scheme) {
                 case "http":
-                    _stream = new TCPSocketStream().connect(uri.host, uri.port, _timeout);
+                    _stream = new TCPStream().connect(uri.host, uri.port, _timeout);
                     break;
                 case "https":
-                    _stream = new SSLSocketStream().connect(uri.host, uri.port, _timeout);
+                    _stream = new SSLStream().connect(uri.host, uri.port, _timeout);
                     break;
             }
         } else {

--- a/source/requests/http.d
+++ b/source/requests/http.d
@@ -44,15 +44,9 @@ package unittest {
     assert(urlEncoded(`abc !#$&'()*+,/:;=?@[]`) == "abc%20%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D");
 }
 
-public class TimeoutException: Exception {
-    this(string msg, string file = __FILE__, size_t line = __LINE__) @safe pure {
-        super(msg, file, line);
-    }
-}
-
 public class MaxRedirectsException: Exception {
-    this(string msg, string file = __FILE__, size_t line = __LINE__) @safe pure {
-        super(msg, file, line);
+    this(string message, string file = __FILE__, size_t line = __LINE__, Throwable next = null) @safe pure nothrow {
+        super(message, file, line, next);
     }
 }
 

--- a/source/requests/streams.d
+++ b/source/requests/streams.d
@@ -874,3 +874,11 @@ public class TCPSocketStream : SocketStream {
     }
 }
 
+version (vibeD) {
+    public alias TCPStream = TCPVibeStream;
+    public alias SSLStream = SSLVibeStream;
+}
+else {
+    public alias TCPStream = TCPSocketStream;
+    public alias SSLStream = SSLSocketStream;
+}

--- a/source/requests/streams.d
+++ b/source/requests/streams.d
@@ -19,16 +19,23 @@ import std.socket;
 alias InDataHandler = DataPipeIface!ubyte;
 
 public class ConnectError: Exception {
-    this(string msg, string file = __FILE__, size_t line = __LINE__) @safe pure {
-        super(msg, file, line);
+    this(string message, string file =__FILE__, size_t line = __LINE__, Throwable next = null) @safe pure nothrow {
+        super(message, file, line, next);
     }
 }
 
 class DecodingExceptioin: Exception {
-    this(string msg, string file = __FILE__, size_t line = __LINE__) @safe pure {
-        super(msg, file, line);
+    this(string message, string file =__FILE__, size_t line = __LINE__, Throwable next = null) @safe pure nothrow {
+        super(message, file, line, next);
     }
 }
+
+public class TimeoutException: Exception {
+    this(string message, string file = __FILE__, size_t line = __LINE__, Throwable next = null) @safe pure nothrow {
+        super(message, file, line, next);
+    }
+}
+
 /**
  * DataPipeIface can accept some data, process, and return processed data.
  */


### PR DESCRIPTION
This pull request adds support for vibe.d as a backend.

I had to do some refactoring to make this possible. I had to move errno checking into the Stream classes and it became obvious that dlang-requests is quite inconsistent when error checking. Some calls do enforce timeouts, some don't. Some calls throw exceptions, some don't. I tried to keep the error handling behaviour unchanged, but I recommend to unify error handling later on (e.g. always propagate TimeoutExceptions: https://github.com/ikod/dlang-requests/commit/ee7e64e506a9f14601f593bb81db76aea9cdadcf#diff-5afa5611d415deda31281152a84a7b8aL109).

Note:
* vibe.d does not support write timeouts or timeouts when connecting. See https://github.com/rejectedsoftware/vibe.d/issues/1137
* I'm not sure if the timeout implementation for SSL is 100% bullet proof. By calling `waitForData` first we enforce the timeout. But if the data received is only TLS management data `leastSize` might block, as the stream is not empty (so it can't return 0) and it can't return a value > 0 as there's no decrypted data. So it'll probably read data from the stream, without enforcing the timeout. OTOH there's no better way to implement the timeout (there's the `readTimeout` property, but this will close the connection and make it difficult to throw an TimeoutException. Additionally the timeout semantics are different as well: https://github.com/rejectedsoftware/vibe.d/issues/622).
