### PR TITLE
Set standard_ports in shared static this

### DIFF
--- a/source/requests/utils.d
+++ b/source/requests/utils.d
@@ -2,8 +2,8 @@ module requests.utils;
 
 import std.range;
 
-static immutable short[string] standard_ports;
-static this() {
+__gshared immutable short[string] standard_ports;
+shared static this() {
     standard_ports["http"] = 80;
     standard_ports["https"] = 443;
     standard_ports["ftp"] = 21;


### PR DESCRIPTION
This is a minor fix: I found this problem when testing the advanced vibe.d example. `static this` constructors execute after `shared static this` constructors. This means that dlang-requests can't be used in `shared static this` constructors, but vibe.d applications usually use the `shared static this` constructors.

As a fix, make `standard_ports` global and use a `shared static this` constructor.