### PR TITLE
miscellanous grammar/formatting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ HTTP requests library with goals:
 
 API docs: [Wiki](https://github.com/ikod/dlang-requests/wiki)
 
+
 ### Library configurations ###
 
-This library can either use the standard std.socket library or [vibe.d](http://vibed.org) for network IO. By default this library uses the standard std.socket configuration called *std*. To build vibe.d variant use the *vibed* configuration (see code example below):
+This library can either use standard `std.socket` library or [`vibe.d`](http://vibed.org) for network IO. By default this library uses the standard `std.socket` configuration called `std`. To build `vibed` variant, use the `vibed` configuration:
 
 ```json
 "dependencies": {
@@ -23,76 +24,97 @@ This library can either use the standard std.socket library or [vibe.d](http://v
 }
 ```
 
-### Make a simple Request ###
 
-Making http/https/ftp request with dlang-requests is simple. First of all install and import *requests* module:
+### Make a simple request ###
+
+Making HTTP/HTTPS/FTP requests with `dlang-requests` is simple. First of all, install and import `requests` module:
+
 ```d
 import requests;
 ```
-If you need just content of some webpage, then you can use getContent:
+
+If you only need content of some webpage, you can use `getContent()`:
+
 ```d
 auto content = getContent("http://httpbin.org/");
 ```
-*getContent* fetch complete document to buffer and return this buffer to the caller. *content* can be converted to string, or can be used as range. For example, if you need to count lines in *content*, you can directly apply *splitter* and *count*:
+
+`getContent()` will fetch complete document to buffer and return this buffer to the caller. `content` can be converted to string, or can be used as range. For example, if you need to count lines in `content`, you can directly apply `splitter()` and `count`:
+
 ```d
 writeln(content.splitter('\n').count);
 ```
-or count non-empty lines:
+
+Count non-empty lines:
+
 ```d
 writeln(content.splitter('\n').filter!"a!=``".count);
 ```
- Actually buffer is *ForwardRange* with *length* and *random access*, so you can apply many algorithms directly to it. Or you can extract data in form of ubyte[], using method data:
+
+Actually, the buffer is a `ForwardRange` with `length` and random access, so you can apply many algorithms directly to it. Or you can extract data in form of `ubyte[]`, using `data` property:
+
 ```d
 ubyte[] data = content.data;
 ```
-### Request with Parameters ###
 
-Requests propose simple way to make request with parameters. For example you have to simulate a search query for person: **name** - person name, **age** - person age, and so on... You can pass all parameters to get using *queryParams()* helper:
+
+### Request with parameters ###
+
+`dlang-requests` proposes simple way to make a request with parameters. For example, you have to simulate a search query for person: **name** - person name, **age** - person age, and so on... You can pass all parameters to get using `queryParams()` helper:
+
 ```d
 auto content = getContent("http://httpbin.org/get", queryParams("name", "any name", "age", 42));
 ```
-If you check httpbin response, you will see how server recognized all parameters:
-```d
-    {
-      "args": {
-        "age": "42",
-        "name": "any name"
-      },
-      "headers": {
-        "Accept-Encoding": "gzip, deflate",
-        "Host": "httpbin.org",
-        "User-Agent": "dlang-requests"
-      },
-      "origin": "xxx.xxx.xxx.xxx",
-      "url": "http://httpbin.org/get?name=any name&age=42"
-    }
+
+If you check httpbin response, you will see that server recognized all parameters:
+
+```json
+{
+  "args": {
+    "age": "42",
+    "name": "any name"
+  },
+  "headers": {
+    "Accept-Encoding": "gzip, deflate",
+    "Host": "httpbin.org",
+    "User-Agent": "dlang-requests"
+  },
+  "origin": "xxx.xxx.xxx.xxx",
+  "url": "http://httpbin.org/get?name=any name&age=42"
+}
 ```
+
 Or, you can pass dictionary:
+
 ```d
 auto content = getContent("http://httpbin.org/get", ["name": "any name", "age": "42"]);
 ```
-Which give you the same response.
 
-### If getContent fails###
+Which gives you the same response.
 
- *getContent()* (and any other API call) can throw exceptions:
 
- * *ConnectError* when we can't connect to document origin for some reason (can't resolve name, connection refused,...)   
- * *TimeoutException* when any single operation *connect, receive, send* timed out.  
- * *ErrnoException* when we geceive ErrnoException from
-   any underlying call.
- * *RequestException* in case in some other
-   cases.
+### If `getContent()` fails###
+
+ `getContent()` (and any other API call) can throw the following exceptions:
+
+ * `ConnectError` when it can't connect to document origin for some reason (can't resolve name, connection refused, ...)   
+ * `TimeoutException` when any single operation *(connect, receive, send)* timed out.  
+ * `ErrnoException` when received `ErrnoException` from any underlying call.
+ * `RequestException` in some other cases.
+
 
 ### Posting data to server ###
-The easy way to post with Requests is *postContent*. There are several way to post data to server:
 
- 1. Post to web-form using "form-urlencode" - for posting short data.
- 2. Post to web-form using multipart - for large data and file uploads.
- 3.  Post data to server without forms.
+The easy way to post with `dlang-requests` is `postContent()`. There are several ways to post data to server:
+
+ 1. Post to web-form using `application/x-www-form-urlencoded` - for posting short data.
+ 1. Post to web-form using `multipart/form-data` - for large data and file uploads.
+ 1. Post data to server without forms.
 
 #### Form-urlencode ####
-Call postContent in the same way as getContent with parameters:
+
+Call `postContent()` in the same way as `getContent()` with parameters:
+
 ```d
 import std.stdio;
 import requests;
@@ -102,30 +124,35 @@ void main() {
     writeln(content);
 }
 ```
+
 Output:
+
+```json
+{
+  "args": {},
+  "data": "",
+  "files": {},
+  "form": {
+    "age": "42",
+    "name": "any name"
+  },
+  "headers": {
+    "Accept-Encoding": "gzip, deflate",
+    "Content-Length": "22",
+    "Content-Type": "application/x-www-form-urlencoded",
+    "Host": "httpbin.org",
+    "User-Agent": "dlang-requests"
+  },
+  "json": null,
+  "origin": "xxx.xxx.xxx.xxx",
+  "url": "http://httpbin.org/post"
+}
 ```
-    {
-      "args": {},
-      "data": "",
-      "files": {},
-      "form": {
-        "age": "42",
-        "name": "any name"
-      },
-      "headers": {
-        "Accept-Encoding": "gzip, deflate",
-        "Content-Length": "22",
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Host": "httpbin.org",
-        "User-Agent": "dlang-requests"
-      },
-      "json": null,
-      "origin": "xxx.xxx.xxx.xxx",
-      "url": "http://httpbin.org/post"
-    }
-```
+
 #### Multipart form ####
-Posting multipart forms required MultipartForm structure to be prepared:
+
+Posting multipart forms requires `MultipartForm` structure to be prepared:
+
 ```d
 import std.stdio;
 import std.conv;
@@ -141,7 +168,11 @@ void main() {
     writeln("Output:");
     writeln(content);
 }
+```
+
 Output:
+
+```json
 {
   "args": {},
   "data": "",
@@ -163,7 +194,9 @@ Output:
   "url": "http://httpbin.org/post"
 }
 ```
-Here is example on posting file:
+
+Here is an example of posting a file:
+
 ```d
 import std.stdio;
 import std.conv;
@@ -179,8 +212,11 @@ void main() {
     writeln("Output:");
     writeln(content);
 }
+```
 
 Output:
+
+```json
 {
   "args": {},
   "data": "",
@@ -202,8 +238,11 @@ Output:
   "url": "http://httpbin.org/post"
 }
 ```
+
 #### Posting raw data without forms ####
-*postContent()* can post from InputRanges. For example to post file content:
+
+`postContent()` can post from `InputRange`s. For example, to post file content:
+
 ```d
 import std.stdio;
 import requests;
@@ -217,8 +256,11 @@ void main() {
     writeln("Output:");
     writeln(content);
 }
+```
 
 Output:
+
+```json
 {
   "args": {},
   "data": "this is test file\n",
@@ -236,15 +278,19 @@ Output:
   "url": "http://httpbin.org/post"
 }
 ```
-Or if your keep your data in memory, then just use something like this:
+
+Or, if you keep your data in memory, you can use something like this:
+
 ```d
 auto content = postContent("http://httpbin.org/post", "ABCDEFGH", "application/binary");
 ```
-That is all details about simple API with default request parameters. Next section will describe a lower level interface through *Request* structure.
 
-### Request() structure ###
+Those are all details about simple API with default request parameters. The next section will describe a lower-level interface through `Request` structure.
 
-When you need to configure request details (like timeouts and other limits, keepalive, ssl properties), or to response details (code, headers) you have to use *Request* and *Response* structures:
+
+### `Request` structure ###
+
+When you need to configure request details (like timeouts and other limits, keep-alive, ssl properties), or response details (code, headers), you have to use `Request` and `Response` structures:
 
 ```d
 Request rq = Request();
@@ -252,7 +298,8 @@ Response rs = rq.get("https://httpbin.org/");
 assert(rs.code==200);
 ```
 
-By default we use KeepAlive requests, so you can reuse connection:
+By default Keep-Alive requests are used, so you can reuse the connection:
+
 ```d
 import std.stdio;
 import requests;
@@ -267,51 +314,54 @@ void main()
     writeln(rs.responseBody.length);
 }
 ```
-In the latter case rq.get() will reuse previous connection to server. Request() will automatically reopen connection when host, protocol or port changes(so it is safe to send different requests through single instance of Request). It also recover when server prematurely close keepalive connection. You can turn keepAlive off when needed:
+
+In the latter case `rq.get()` will reuse previous connection to server. `Request` will automatically reopen connection when host, protocol or port change (so it is safe to send different requests through single instance of `Request`). It also recovers when server prematurely closes keep-alive connection. You can turn `keepAlive` off when needed:
+
 ```d
 rq.keepAlive = false;
 ```
 
-For anything other than default, you can configure *Request* structure for keep-alive, redirects handling, add/remove headers, set io-buffer size and maximum size of response headers and body.
+For anything other than default, you can configure `Request` structure for keep-alive, redirects handling, to add/remove headers, set IO buffer size and maximum size of response headers and body.
 
-For example to authorize with Basic authorization use next code (works both for http and ftp url's):
+For example, to authorize with basic authentication, use the following code (works both for HTTP and FTP URLs):
+
 ```d
 rq = Request();
 rq.authenticator = new BasicAuthentication("user", "passwd");
 rs = rq.get("http://httpbin.org/basic-auth/user/passwd");
 ```
 
-Here is short description of some Request options, you can set:
+Here is a short description of some `Request` options you can set:
 
-| name                | type           | meaning                                | default    |
-|---------------------|----------------|----------------------------------------|------------|
-| keepAlive           | bool           | request keepalive connection           | false      |
-| maxRedirects *)     | uint           | maximum redirect depth                 | 10         |
-| maxHeadersLength *) | size_t         | max.acceptable response headers length | 32KB       |
-| maxContentLength *) | size_t         | max.acceptable content length          | 5MB        |
-| timeout *)          | Duration       | timeout on connect or data transfer    | 30.seconds |
-| bufferSize          | size_t         | socket io buffer size                  | 16KB       |
-| verbosity           | uint           | verbosity level (0, 1, 2 or 3)         | 0          |
-| proxy               | string         | url of the http proxy                  | null       |
-| headers             | string[string] | additional headers                     | null       |
-| useStreaming        | bool           | receive data as lazy InputRange        | false      |
-| cookie              | Cookie[]       | cookies you will send to server        | null       |
-| authenticator       | Auth           | authenticatior                         | null       |
+| name                | type             | meaning                                 | default    |
+|---------------------|------------------|-----------------------------------------|------------|
+| keepAlive           | `bool`           | request keepalive connection            | false      |
+| maxRedirects *)     | `uint`           | maximum redirect depth                  | 10         |
+| maxHeadersLength *) | `size_t`         | max. acceptable response headers length | 32KB       |
+| maxContentLength *) | `size_t`         | max. acceptable content length          | 5MB        |
+| timeout *)          | `Duration`       | timeout on connect or data transfer     | 30.seconds |
+| bufferSize          | `size_t`         | socket io buffer size                   | 16KB       |
+| verbosity           | `uint`           | verbosity level (0, 1, 2 or 3)          | 0          |
+| proxy               | `string`         | url of the HTTP proxy                   | null       |
+| headers             | `string[string]` | additional headers                      | null       |
+| useStreaming        | `bool`           | receive data as lazy `InputRange`       | false      |
+| cookie              | `Cookie[]`       | cookies you will send to server         | null       |
+| authenticator       | `Auth`           | authenticatior                          | null       |
 
-*) Throw exception when limit reached.
+*) Throws exception when limit is reached.
 
 
-Request() properties you can read:
+`Request` properties that are read-only:
 
-| name             | type           | meaning                                             |
-|------------------|----------------|-----------------------------------------------------|
-| cookie           | Cookie[]       | cookie, server sent to us                           |
-| contentLength    | long           | current document content Length or -1 if unknown    |
-| contentReceived  | long           | content recived                                     |
+| name             | type             | meaning                                             |
+|------------------|------------------|-----------------------------------------------------|
+| cookie           | `Cookie[]`       | cookie the server sent to us                        |
+| contentLength    | `long`           | current document's content length or -1 if unknown  |
+| contentReceived  | `long`           | content received                                    |
 
 #### Streaming server response ####
-With *useStreaming* you can receive response body as input range.
-contentLength and contentReceived can be used to monitor progress:
+With `useStreaming`, you can receive response body as input range.
+`contentLength` and `contentReceived` can be used to monitor progress:
 
 ```d
 import std.stdio;
@@ -330,7 +380,9 @@ void main()
     }
 }
 ```
-Produce console output:
+
+Output:
+
 ```
 > GET /image/jpeg HTTP/1.1
 > Connection: Keep-Alive
@@ -364,7 +416,9 @@ Received 2896 bytes, total received 31640 from document legth 35588
 Received 2896 bytes, total received 34536 from document legth 35588
 Received 1052 bytes, total received 35588 from document legth 35588
 ```
-With verbosity>=3 you will receive also dump of each data portion received from sockets:
+
+With `verbosity >= 3`, you will also receive a dump of each data portion received from sockets:
+
 ```
 00000  48 54 54 50 2F 31 2E 31  20 32 30 30 20 4F 4B 0D  |HTTP/1.1 200 OK.|
 00010  0A 53 65 72 76 65 72 3A  20 6E 67 69 6E 78 0D 0A  |.Server: nginx..|
@@ -378,8 +432,10 @@ With verbosity>=3 you will receive also dump of each data portion received from 
 ...
 
 ```
-Just for fun: with streaming you can forward content between servers in just two code lines. postContent will authomatically receive next data portion from source and send it to destination:
-```
+
+Just for fun: with streaming you can forward content between servers in just two code lines. `postContent` will automatically receive next data portion from source and send it to destination:
+
+```d
 import requests;
 
 void main()
@@ -391,8 +447,9 @@ void main()
 }
 ```
 
-You can use *requests* in parallel tasks (but you can't share single *Request* structure between threads):
-```
+You can use `dlang-requests` in parallel tasks (but you can't share the same `Request` structure between threads):
+
+```d
 import std.stdio;
 import std.parallelism;
 import std.algorithm;
@@ -420,8 +477,11 @@ void main() {
     assert(lines == 287);
 }
 ```
+
 #### vibe.d ####
-You can safely use *requests* with vibe.d. When *requests* compiled with support for vibe.d sockets (--config=vibed), each call to *requests* API can block only current fiber, not thread:
+
+You can safely use `dlang-requests` with `vibe.d`. When `dlang-requests` is compiled with support for `vibe.d` sockets (`--config=vibed`), each call to `dlang-requests` API can block only the current fiber, not the thread:
+
 ```d
 import requests, vibe.d;
 
@@ -440,9 +500,11 @@ shared static this()
     for(size_t i = 0; i < 3; i++)
         runTask(&taskMain);
 }
+```
 
-output:
+Output:
 
+```
 [F7EC2FAB:F7ECD7AB 2016.07.05 16:55:54.115 INF] Task created
 [F7EC2FAB:F7ECD3AB 2016.07.05 16:55:54.116 INF] Task created
 [F7EC2FAB:F7ED6FAB 2016.07.05 16:55:54.116 INF] Task created
@@ -452,12 +514,13 @@ output:
 [F7EC2FAB:F7ECD7AB 2016.07.05 16:55:57.827 INF] Google request finished
 [F7EC2FAB:F7ECD3AB 2016.07.05 16:55:57.836 INF] Google request finished
 [F7EC2FAB:F7ED6FAB 2016.07.05 16:55:57.856 INF] Google request finished
-
 ```
-#### Adding/replacing request headers ###
-Use string[string] and addHeaders method to add or replace some request headers:
 
- ```d
+#### Adding/replacing request headers ###
+
+Use `string[string]` and `addHeaders()` method to add or replace some request headers:
+
+```d
 import requests;
 
 void main() {
@@ -466,7 +529,11 @@ void main() {
     rq.addHeaders(["User-Agent": "test-123", "X-Header": "x-value"]);
     auto rs = rq.post("http://httpbin.org/post", `{"a":"b"}`, "application/x-www-form-urlencoded");
 }
+```
+
 Output:
+
+```
 > POST /post HTTP/1.1
 > Content-Length: 9
 > Connection: Keep-Alive
@@ -480,6 +547,7 @@ Output:
 < server: nginx
 ...
 ```
+
 #### SSL settings ####
 
 HTTP requests can be configured for SSL options: you can enable or disable remote server certificate verification, set key and certificate to use for authorizing to remote server:
@@ -500,21 +568,25 @@ void main() {
     writeln(rs.responseBody);
 }
 ```
-Please note that with vibe.d you have to add call
+
+Please note that with `vibe.d` you have to add the following call
+
 ```d
 rq.sslSetCaCert("/opt/local/etc/openssl/cert.pem");
 ```
-with path to CA cert file(location may differ for different OS or openssl packaging).
+
+with path to CA cert file (location may differ for different OS or openssl packaging).
+
 
 ### FTP requests ###
 
 You can use the same structure to make ftp requests, both get and post.
 
-HTTP specific methods do not work if request use `ftp` scheme.
+HTTP-specific methods do not work if request uses `ftp` scheme.
 
-Here is example:
+Here is an example:
 
-```
+```d
 import std.stdio;
 import requests;
 
@@ -530,24 +602,26 @@ void main() {
 }
 ```
 
-Second argument for ftp posts can be anything that can be casted to ubyte[] or any InputRange with element type like ubyte[].
-If path in the post request doesn't exists, then we will try to create all required directories.
-As with HTTP you can call several ftp requests using same Request structure - we will reuse established connection (and authorization).
+Second argument for FTP posts can be anything that can be casted to `ubyte[]` or any `InputRange` with element type like `ubyte[]`.
+If the path in the post request doesn't exist, it will try to create all the required directories.
+As with HTTP, you can call several FTP requests using the same `Request` structure - it will reuse established connection (and authorization as well).
 
-### Response() structure ###
 
-This structure present details about received response.
+### `Response` structure ###
 
-Most frequently needed parts of response are:
+This structure provides details about received response.
 
-* code - http or ftp response code as received from server.
-* responseBody - contain complete document body when no streaming in use. You can't use it when in streaming mode.
-* responseHeaders - response headers in form of string[string] (not available for ftp requests)
-* receiveAsRange - if you set useStreaming in the Request, then receiveAsRange will provide elements(type ubyte[]) of InputRange while receiving data from the server.
+Most frequently needed parts of `Response` are:
+
+* `code` - HTTP or FTP response code as received from server.
+* `responseBody` - contain complete document body when no streaming is in use. You can't use it when in streaming mode.
+* `responseHeaders` - response headers in form of `string[string]` (not available for FTP requests)
+* `receiveAsRange` - if you set `useStreaming` in the `Request`, then `receiveAsRange` will provide elements (type `ubyte[]`) of `InputRange` while receiving data from the server.
+
 
 ### Low level details ###
 
-At the lowest level Request() use several templated overloads of single call exec(). Using this method you can call other than GET or POST HTTP methods (Attention: you have to use HTTPRequest instead of Request, as this calls are specific to HTTP):
+At the lowest level `Request` uses several templated overloads of a single `exec()` call. Using this method, you can call HTTP methods other than GET or POST (Attention: you have to use `HTTPRequest` instead of just `Request`, as these methods calls are specific to HTTP):
 
 ```d
 #!/usr/bin/env rdmd -I./source librequests.a -L-lssl -L-lcrypto y.d
@@ -563,7 +637,11 @@ void main()
     auto rs = rq.exec!"PUT"("http://httpbin.org/put?exampleTitle=PUT%20content", file.byChunk(1024));
     writeln(rs.responseBody);
 }
+```
 
+Output:
+
+```
 > PUT /put?exampleTitle=PUT%20content HTTP/1.1
 > Transfer-Encoding: chunked
 > Connection: Keep-Alive
@@ -603,53 +681,52 @@ void main()
 
 #### Requests Pool ####
 
-When you have a large number of requests to execute, you can use request pool to speed things up.
+When you have a large number of requests to execute, you can use a request pool to speed things up.
 
-Pool is fixed set of worker threads, receiving request *Job*'s, and returing *Result*'s.
+A `pool` is a fixed set of worker threads, which receives requests in form of `Job`s and returns `Result`s.
 
-Each Job can be configured for URL, method, data (for POST requests) and some other parameters.
+Each `Job` can be configured for an URL, method, data (for POST requests) and some other parameters.
 
-Pool act as parallel map from Jobs to Results - consume InputRange of *Job*'s, and produce *InputRange* of *Result*'s as fast as it can.
+`pool` acts as a parallel `map` from `Job` to `Result` - it consumes `InputRange` of `Job`s, and produces `InputRange` of `Result`s as fast as it can.
 
-It is important to note that Pool do not preserve result order. If you need somehow tie jobs and results, you can use Job's *opaque* field.
+It is important to note that `pool` does not preserve result order. If you need to tie jobs and results somehow, you can use the `opaque` field of `Job`.
 
-Here is sample of usage:
+Here is an example usage:
 
 ```d
-    Job[] jobs = [
-        Job("http://httpbin.org/get").addHeaders([
-                            "X-Header": "X-Value",
-                            "Y-Header": "Y-Value"
-                        ]),
-        Job("http://httpbin.org/gzip"),
-        Job("http://httpbin.org/deflate"),
-        Job("http://httpbin.org/absolute-redirect/3")
-                .maxRedirects(2),                   // limit redirects
-        Job("http://httpbin.org/range/1024"),
-        Job("http://httpbin.org/post")
-                .method("POST")                     // change default GET to POST
-                .data("test".representation())      // attach data for POST
-                .opaque("id".representation),       // opaque data - you will receive the same in Result
-        Job("http://httpbin.org/delay/3")
-                .timeout(1.seconds),                // set timeout to 1.seconds - this request will throw exception and fails
-        Job("http://httpbin.org/stream/1024"),
-        Job("ftp://speedtest.tele2.net/1KB.zip"),   // ftp requests too
-    ];
+Job[] jobs = [
+    Job("http://httpbin.org/get").addHeaders([
+                        "X-Header": "X-Value",
+                        "Y-Header": "Y-Value"
+                    ]),
+    Job("http://httpbin.org/gzip"),
+    Job("http://httpbin.org/deflate"),
+    Job("http://httpbin.org/absolute-redirect/3")
+            .maxRedirects(2),                   // limit redirects
+    Job("http://httpbin.org/range/1024"),
+    Job("http://httpbin.org/post")
+            .method("POST")                     // change default GET to POST
+            .data("test".representation())      // attach data for POST
+            .opaque("id".representation),       // opaque data - you will receive the same in Result
+    Job("http://httpbin.org/delay/3")
+            .timeout(1.seconds),                // set timeout to 1.seconds - this request will throw exception and fails
+    Job("http://httpbin.org/stream/1024"),
+    Job("ftp://speedtest.tele2.net/1KB.zip"),   // ftp requests too
+];
 
-    auto count = jobs.
-        pool(5).
-        filter!(r => r.code==200).
-        count();
+auto count = jobs.
+    pool(5).
+    filter!(r => r.code==200).
+    count();
 
-    assert(count == jobs.length - 2, "failed");
-    // generate post data from input range
-    // and process in 10 workers pool
-    iota(20)
-        .map!(n => Job("http://httpbin.org/post")
-                        .data("%d".format(n).representation))
-        .pool(10)
-        .each!(r => assert(r.code==200));
-
+assert(count == jobs.length - 2, "failed");
+// generate post data from input range
+// and process in 10 workers pool
+iota(20)
+    .map!(n => Job("http://httpbin.org/post")
+                    .data("%d".format(n).representation))
+    .pool(10)
+    .each!(r => assert(r.code==200));
 ```
 
 One more example, with more features combined:
@@ -685,9 +762,11 @@ void main() {
         writeln("---");
     }
 }
+```
 
 Output:
 
+```
 2016-12-29T10:22:00.861:streams.d:connect:973 Failed to connect to 0.0.0.0:9998(0.0.0.0:9998): Unable to connect socket: Connection refused
 2016-12-29T10:22:00.861:streams.d:connect:973 Failed to connect to 0.0.0.0:9998(0.0.0.0:9998): Unable to connect socket: Connection refused
 Exception: Can't connect to 0.0.0.0:9998
@@ -737,28 +816,29 @@ Exception: 2 redirects reached maxRedirects 2.
 ---
 ```
 
-*Job* methods
+`Job` methods
 
-| name        | parameter type           | description           |
-|-------------|--------------------------|-----------------------|
-| method      | *string* "GET" or "POST" | request method        |
-| data        | immutable(ubyte)[]       | data for POST request |
-| timeout     | Duration                 | timeout for network io|
-| maxRedirects| uint                     | max N of redirects    |
-| opaque      | immutable(ubyte)[]       | opaque data           |
-| addHeaders  | string[string]           | headers to add to rq  |
+| name        | parameter type             | description               |
+|-------------|----------------------------|---------------------------|
+| method      | `string` "GET" or "POST"   | request method            |
+| data        | `immutable(ubyte)[]`       | data for POST request     |
+| timeout     | `Duration`                 | timeout for network IO    |
+| maxRedirects| `uint`                     | max. no. of redirects     |
+| opaque      | `immutable(ubyte)[]`       | opaque data               |
+| addHeaders  | `string[string]`           | headers to add to request |
 
-*Result* fields
+`Result` fields
 
-| name   | type             | description          |
-|--------|------------------|----------------------|
-| flags  | uint             | flags  (OK,EXCEPTION)|
-| code   |ushort            | response code        |
-| data   |immutable(ubyte)[]| response body        |
-| opaque |immutable(ubyte)[]| opaque data from job |
+| name   | type                 | description          |
+|--------|----------------------|----------------------|
+| flags  | `uint`               | flags (OK,EXCEPTION) |
+| code   | `ushort`             | response code        |
+| data   | `immutable(ubyte)[]` | response body        |
+| opaque | `immutable(ubyte)[]` | opaque data from job |
+
 
 ### Pool limitations ###
 
-1. currently it doesn't work under vibe.d - use vibe.d parallelisation
-1. it limits you in tuning request (e.g. you can add authorization only through addHeaders, you can't tune SSL parameters, etc)
-1. *Job* and *Result* *data* are immutable byte arrays (as we use send/receive for data exchange)
+1. Currently it doesn't work under `vibe.d` - use `vibe.d` parallelisation.
+1. It limits you in tuning request (e.g. you can add authorization only through `addHeaders()`, you can't tune SSL parameters, etc).
+1. `Job`'s' and `Result`'s' `data` are immutable byte arrays (as it uses send/receive for data exchange).


### PR DESCRIPTION
this mostly involves formatting fixes: explicit code syntax settings (`d`/`json`), methods and classes wrapped in a nice pair of backticks and suchs. did this mostly because [the readme @ package index](http://code.dlang.org/packages/requests) was a disaster due to an occasional space before the code block (see everything after "Adding/replacing request headers" there; `code.dlang.org`'s formatter choked on that one)

no code samples were changed, unless there was an extra indentation block