### PR TITLE
Allow using VibeD 0.8.0

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -16,7 +16,7 @@
             "name": "vibed",
             "versions": ["vibeD"],
             "dependencies": {
-                "vibe-d": "~>0.7.29"
+                "vibe-d": ">=0.7.29"
             },
         }
     ],


### PR DESCRIPTION
Changed dub.json to allow vibe-d version >= 0.7.29, fixing the issue that prevents using vibe-d 0.8.0 in a project together with Requests.