### PR TITLE
requests.streams: Adapt to some changed std.socket.Socket class membe…

### DIFF
--- a/source/requests/streams.d
+++ b/source/requests/streams.d
@@ -804,17 +804,17 @@ else {
             return this;
         }
         @trusted
-        override ptrdiff_t send(const(void)[] buf, SocketFlags flags) {
+        override ptrdiff_t send(const(void)[] buf, SocketFlags flags) scope {
             return openssl.SSL_write(ssl, buf.ptr, cast(uint) buf.length);
         }
-        override ptrdiff_t send(const(void)[] buf) {
+        override ptrdiff_t send(const(void)[] buf) scope {
             return send(buf, SocketFlags.NONE);
         }
         @trusted
-        override ptrdiff_t receive(void[] buf, SocketFlags flags) {
+        override ptrdiff_t receive(void[] buf, SocketFlags flags) scope {
             return openssl.SSL_read(ssl, buf.ptr, cast(int)buf.length);
         }
-        override ptrdiff_t receive(void[] buf) {
+        override ptrdiff_t receive(void[] buf) scope {
             return receive(buf, SocketFlags.NONE);
         }
         this(AddressFamily af, SocketType type = SocketType.STREAM, SSLOptions opts = SSLOptions()) {
@@ -825,7 +825,7 @@ else {
             super(sock, af);
             initSsl(opts);
         }
-        override void close() {
+        override void close() scope {
             //SSL_shutdown(ssl);
             super.close();
         }


### PR DESCRIPTION
…r function signatures

My phobos PR 6204 (dedicated to have std.socket compilable with -dip1000) https://github.com/dlang/phobos/pull/6204
fails continuous-integration/jenkins/pr-merge  with Your library:
https://ci.dlang.io/blue/organizations/jenkins/dlang-org%2Fphobos/detail/PR-6204/1/pipeline/211
with these errors (exactly where I changed std.socket.Socket mem fun signatures) :
```
[dlang-requests] Running shell script
+ dub build -c std
Performing "debug" build using /var/lib/jenkins/dlang_projects@2/distribution/bin/dmd for x86_64.
requests 0.7.2: building configuration "std"...
source/requests/streams.d(807,28): Error: function `requests.streams.OpenSslSocket.send` does not override any function, did you mean to override `std.socket.Socket.send`?
source/requests/streams.d(810,28): Error: function `requests.streams.OpenSslSocket.send` does not override any function, did you mean to override `std.socket.Socket.send`?
source/requests/streams.d(814,28): Error: function `requests.streams.OpenSslSocket.receive` does not override any function, did you mean to override `std.socket.Socket.receive`?
source/requests/streams.d(817,28): Error: function `requests.streams.OpenSslSocket.receive` does not override any function, did you mean to override `std.socket.Socket.receive`?
source/requests/streams.d(828,23): Error: function `requests.streams.OpenSslSocket.close` does not override any function, did you mean to override `std.socket.Socket.close`?
/var/lib/jenkins/dlang_projects@2/distribution/bin/dmd failed with exit code 1.
script returned exit code 2
```

Depending on fortune of PR 6204 You might want to adapt public class OpenSslSocket : Socket
as suggested by this PR (though Your library's -dip1000 build will fail due to still some other -dip1000 issues).

With proposed changes applied, unittesting Your library will fail as long as PR 6204 didn't get into a release:
```
user@host:~/git/dlang-requests$ dub build --force
Performing "debug" build using /usr/bin/dmd for x86_64.
requests 0.7.2+commit.1.gde40804: building configuration "std"...
Compiling httpbin server
user@host:~/git/dlang-requests$ dub test --force
Generating test runner configuration 'requests-test-std' for 'std' (library).
Excluding package.d file from test due to https://issues.dlang.org/show_bug.cgi?id=11847
Excluding package.d file from test due to https://issues.dlang.org/show_bug.cgi?id=11847
Performing "unittest" build using /usr/bin/dmd for x86_64.
idna 0.0.1: building configuration "std"...
requests 0.7.2+commit.1.gde40804: building configuration "requests-test-std"...
Compiling httpbin server
Linking...
.dub/build/requests-test-std-unittest-linux.posix-x86_64-dmd_2078-27D568902877986664F6CE3708C0D051/requests-test-std.o: In Funktion `_D8requests7streams13OpenSslSocket5closeMFNbNiNlNfZv':
/home/bodo/git/dlang-requests/source/requests/streams.d:830: Nicht definierter Verweis auf (unresolved symbol) `_D3std6socket6Socket5closeMFNbNiNlNeZv'
collect2: error: ld returned 1 exit status
Error: linker exited with status 1
/usr/bin/dmd failed with exit code 1.
```