### PR TITLE
Libressl loading fix for libressl version >= 2.7.1

### DIFF
--- a/source/requests/ssl_adapter.d
+++ b/source/requests/ssl_adapter.d
@@ -136,6 +136,7 @@ static this() {
     void delegate()[Version] init_matrix;
     init_matrix[Version(1,0)] = &openssl.init1_0;
     init_matrix[Version(1,1)] = &openssl.init1_1;
+    init_matrix[Version(0,2)] = &openssl.init1_1; // libressl >= 2.7.1
     auto init = init_matrix.get(openssl._ver, null);
     if ( init is null ) {
         throw new Exception("loading openssl: unknown version for init");


### PR DESCRIPTION
References #96, `dub test` seems to work properly with the additional `init_matrix` entry.
Thanks!