### PR TITLE
Avoid RangeError in domainMatches()

### DIFF
--- a/source/requests/utils.d
+++ b/source/requests/utils.d
@@ -120,13 +120,16 @@ package unittest {
 package bool domainMatches(string d1, string d2) pure @safe @nogc {
     import std.algorithm;
     return d1==d2 ||
-           (d2[0] == '.' && d1.endsWith(d2));
+           (d2.startsWith(".") && d1.endsWith(d2));
 }
 
 package unittest {
     assert("x.example.com".domainMatches(".example.com"));
     assert(!"x.example.com".domainMatches("example.com"));
+    assert(!"example.com".domainMatches(".x.example.com"));
     assert("example.com".domainMatches("example.com"));
+    assert(!"example.com".domainMatches(""));
+    assert(!"".domainMatches("example.com"));
 }
 
 string[] dump(in ubyte[] data) {


### PR DESCRIPTION
domainMatches() crashes if the second argument is empty.

If the second argument is empty, that's probably a semantic problem that
should be checked and reported in the upstream code.  But this low-level
function should also work without crashing on logically valid cases.