### PR TITLE
Add support for PUT, PATCH and DELETE

### DIFF
--- a/source/requests/http.d
+++ b/source/requests/http.d
@@ -1483,7 +1483,7 @@ public struct HTTPRequest {
         string encoded;
 
         switch (_method) {
-            case "POST","PUT":
+            case "POST","PUT","PATCH":
                 encoded = params2query(params);
                 safeSetHeader(h, _userHeaders.ContentType, "Content-Type", "application/x-www-form-urlencoded");
                 if ( encoded.length > 0) {
@@ -2197,7 +2197,7 @@ public struct HTTPRequest {
         string encoded;
 
         switch (_method) {
-            case "POST","PUT":
+            case "POST","PUT","PATCH":
                 encoded = params2query(_params);
                 safeSetHeader(h, _userHeaders.ContentType, "Content-Type", "application/x-www-form-urlencoded");
                 if ( encoded.length > 0) {

--- a/source/requests/package.d
+++ b/source/requests/package.d
@@ -408,6 +408,34 @@ package unittest {
         assert(s.representation == flat_content.array.map!(i => i.integer).array);
     }
 
+    /// Putting to forms (for small data)
+    ///
+    /// putting query parameters using "application/x-www-form-urlencoded"
+    info("Test putContent using query params");
+    r = putContent(httpbinUrl ~ "put", queryParams("first", "a", "second", 2));
+    assert(parseJSON(cast(string)r).object["form"].object["first"].str == "a");
+    
+    /// putting using multipart/form-data (large data and files). See docs fot HTTPRequest
+    info("Test putContent form");
+    mpform = MultipartForm();
+    mpform.add(formData(/* field name */ "greeting", /* content */ cast(ubyte[])"hello"));
+    r = putContent(httpbinUrl ~ "put", mpform);
+    assert(parseJSON(cast(string)r).object["form"].object["greeting"].str == "hello");
+
+    /// Patching to forms (for small data)
+    ///
+    /// patching query parameters using "application/x-www-form-urlencoded"
+    info("Test patchContent using query params");
+    r = patchContent(httpbinUrl ~ "patch", queryParams("first", "a", "second", 2));
+    assert(parseJSON(cast(string)r).object["form"].object["first"].str == "a");
+    
+    /// patching using multipart/form-data (large data and files). See docs fot HTTPRequest
+    info("Test patchContent form");
+    mpform = MultipartForm();
+    mpform.add(formData(/* field name */ "greeting", /* content */ cast(ubyte[])"hello"));
+    r = patchContent(httpbinUrl ~ "patch", mpform);
+    assert(parseJSON(cast(string)r).object["form"].object["greeting"].str == "hello");
+
     info("Check exception handling, error messages and timeouts are OK");
     rq.clearHeaders();
     rq.timeout = 1.seconds;
@@ -496,6 +524,24 @@ public auto ref getContent(A...)(string url, A args) if (args.length > 1 && args
 public auto postContent(A...)(string url, A args) {
     auto rq = Request();
     auto rs = rq.post(url, args);
+    return rs.responseBody;
+}
+
+///
+/// Call put and return response content.
+///
+public auto putContent(A...)(string url, A args) {
+    auto rq = Request();
+    auto rs = rq.put(url, args);
+    return rs.responseBody;
+}
+
+///
+/// Call patch and return response content.
+///
+public auto patchContent(A...)(string url, A args) {
+    auto rq = Request();
+    auto rs = rq.patch(url, args);
     return rs.responseBody;
 }
 

--- a/source/requests/request.d
+++ b/source/requests/request.d
@@ -527,6 +527,38 @@ public struct Request {
     {
         return execute("GET", uri, params);
     }
+    Response put(string uri, QueryParam[] query)
+    {
+        return execute("PUT", uri, query);
+    }
+    Response put(string uri, MultipartForm form)
+    {
+        return execute("PUT", uri, form);
+    }
+    Response put(R)(string uri, R content, string contentType="application/octet-stream")
+    {
+        return execute("PUT", uri, content, contentType);
+    }
+    Response patch(string uri, QueryParam[] query)
+    {
+        return execute("PATCH", uri, query);
+    }
+    Response patch(string uri, MultipartForm form)
+    {
+        return execute("PATCH", uri, form);
+    }
+    Response patch(R)(string uri, R content, string contentType="application/octet-stream")
+    {
+        return execute("PATCH", uri, content, contentType);
+    }
+    Response deleteRequest(string uri, string[string] query)
+    {
+        return execute("DELETE", uri, aa2params(query));
+    }
+    Response deleteRequest(string uri, QueryParam[] params = null)
+    {
+        return execute("DELETE", uri, params);
+    }
     Response execute(R)(string method, string url, R content, string ct = "application/octet-stream")
     {
         _method = method;
@@ -660,4 +692,15 @@ unittest {
     rs = rq.post("http://httpbin.org/post", "abc");
     assert(rs.code == 200);
     assert(rs.uri().path() == "/get");
+
+    rs = rq.put("http://httpbin.org/put", "abc");
+    assert(rs.code == 200);
+    assert(rs.uri().path() == "/get");
+
+    rs = rq.patch("http://httpbin.org/patch", "abc");
+    assert(rs.code == 200);
+    assert(rs.uri().path() == "/get");
+
+    rs = rq.deleteRequest("http://httpbin.org/delete");
+    assert(rs.uri.path == "/get", "Expected /get, but got %s".format(rs.uri.path));
 }


### PR DESCRIPTION
This is my attempt to add support for PUT, PATCH and DELETE methods.

It adds methods `put`, `patch` and `deleteRequest` (probably could have a better name) to `Request` object + general methods `putContent` and `patchContent`. There is no `deleteContent` though, as I'm not sure it's a good name for it.

Tests are added, mostly by copying and pasting what I found for POST.