### PR TITLE
fix SSL on OSX 10.15

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [macOS-latest]
+        dc: [dmd-latest, ldc-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: D Compiler Installation
+      uses: mihails-strasuns/setup-dlang@v0.3.1
+      with:
+        compiler: ${{ matrix.dc }}
+      
+    - name: Test
+      run: dub test --config=std

--- a/tests/https.d
+++ b/tests/https.d
@@ -1,0 +1,21 @@
+module https;
+
+import requests;
+import std.experimental.logger;
+
+version(vibeD) {
+}
+else {
+    unittest {
+        globalLogLevel(LogLevel.info);
+        auto rq = Request();
+        rq.keepAlive = false;
+        info("Testing https using google.com");
+        auto rs = rq.get("https://google.com");
+        assert(rs.responseBody.length > 0);
+    }
+}
+
+version(unittest_fakemain) {
+void main () {}
+}


### PR DESCRIPTION
fix #110

This also changes the order of the linux binaries so it prefers files with known versions. (To avoid ABI breakage which has happened often in vibe.d before)

Also adds an OSX auto tester using GitHub actions. It can also do windows but I didn't enable it because it currently doesn't pass tests. See https://github.com/WebFreak001/dlang-requests/runs/303570705