### PR TITLE
Exclude unittest files from builds

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,8 +4,8 @@
     "copyright": "Copyright © 2016, igor",
     "authors": ["ikod"],
     "license": "BSL-1.0",
-    "sourcePaths": ["tests", "source"],
-    "importPaths": ["tests", "source"],
+    "sourcePaths": ["source"],
+    "importPaths": ["source"],
     "configurations": [
         {
             "name": "std",
@@ -36,11 +36,13 @@
         "unittest": {
             "buildOptions": ["unittests", "debugMode", "debugInfo"],
             "versions": ["httpbin"],
-            "debugVersions": ["requests", "httpd"]
+            "debugVersions": ["requests", "httpd"],
+            "sourcePaths": ["source", "tests"]
         },
         "localtest": {
             "buildOptions": ["unittests", "debugMode", "debugInfo"],
-            "versions": ["localtest"]
+            "versions": ["localtest"],
+            "sourcePaths": ["source", "tests"]
         }
     }
 }


### PR DESCRIPTION
The unittest modules were causing linking issues for me when the main project already has a module called `app`:
```
requests.lib(app.obj) : error LNK2005: _D3app12__ModuleInfoZ already defined in app.obj
```