### PR TITLE
Hold on to the ConnManager in the HTTPResponse

### DIFF
--- a/source/requests/base.d
+++ b/source/requests/base.d
@@ -231,10 +231,11 @@ public struct ReceiveAsRange {
         }
     }
     package {
-        bool            activated;
-        ubyte[]         data;
+        bool                    activated;
+        ubyte[]                 data;
         /// HTTP or FTP module set up delegate read() for reading next portion of data.
-        ubyte[]         delegate() read;
+        ubyte[]                 delegate() read;
+        RefCounted!ConnManager  cm;
     }
 }
 

--- a/source/requests/http.d
+++ b/source/requests/http.d
@@ -846,6 +846,7 @@ public struct HTTPRequest {
                 _response._contentLength = _contentLength;
                 _response.receiveAsRange.activated = true;
                 _response.receiveAsRange.data = _response._responseBody.data;
+                _response.receiveAsRange.cm = _cm;
                 _response.receiveAsRange.read = delegate ubyte[] () {
 
                     while(true) {


### PR DESCRIPTION
Adds the `RefCounted!ConnManager` to the `HTTPResponse`.

This is needed when `useStreaming` is set and the `HTTPResponse` outlives the `Request` object, otherwise the ref count will go to zero and the connection will be closed before you have time to stream the content.

e.g. in:
```dlang
Response doRequest(string method, string url) {
    // ...
    auto req = Request();
    req.useStreaming = true;
    return req.execute(method, url);
}
void doIt(string method, string url) {
    // right now in the body of the foreach the socket will already be closed 
    // because the Request object has gone out of scope and the connectionmanager is cleaned up
    foreach(chunk; doRequest(method,url).receiveAsRange) { 
        chunk.doSomething
    }
}
```

This change adds the connection manager to the receiveAsRange object so that the socket will be kept open.