### PR TITLE
Explicitly call .get on Nullable in pool.d

### DIFF
--- a/source/requests/pool.d
+++ b/source/requests/pool.d
@@ -339,7 +339,7 @@ public:
             } else
             if ( !idle.isNull ) {
                 debug(requests) tracef("use just released idle (prev job %s) for %s", _m._idle[t], route);
-                t = idle;
+                t = idle.get;
                 idle.nullify();
                 fromIdleToBusy(t, route);
             } else {
@@ -369,7 +369,7 @@ public:
     }
     do {
         if ( !_m._result.isNull ) {
-            return _m._result;
+            return _m._result.get;
         }
         Tid w;
         sendWhilePossible();
@@ -395,7 +395,7 @@ public:
             fromIdleToBusy(w, route);
             _m._sent++;
         }
-        return _m._result;
+        return _m._result.get;
     }
     /**
         helpers


### PR DESCRIPTION
The implicit .get on Nullable was deprecated and removed after version 2.096. This should now be fixed.

Prior to 2.096:
```
/requests-2.0.9/requests/source/requests/pool.d(372,20): Deprecation: function std.typecons.Nullable!(Result).Nullable.get_ is deprecated - Implicit conversion with alias Nullable.get this will be removed after 2.096. Please use .get explicitly.
/requests-2.0.9/requests/source/requests/pool.d(398,16): Deprecation: function std.typecons.Nullable!(Result).Nullable.get_ is deprecated - Implicit conversion with alias Nullable.get this will be removed after 2.096. Please use .get explicitly.
```

After 2.096
```
/requests-2.0.9/requests/source/requests/pool.d(372,20): Error: cannot implicitly convert expression `this._m._result` of type `Nullable!(Result)` to `Result`
/requests-2.0.9/requests/source/requests/pool.d(398,16): Error: cannot implicitly convert expression `this._m._result` of type `Nullable!(Result)` to `Result`
/requests-2.0.9/requests/source/requests/pool.d(342,21): Error: cannot implicitly convert expression `idle` of type `Nullable!(Tid)` to `Tid`
```
