### PR TITLE
Allow partial static build

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -16,8 +16,7 @@
         {
             "name": "staticssl",
             "versions": ["staticssl"],
-            "dflags" : ["-static"],
-            "libs": ["ssl", "crypto"],
+            "libs": [":libssl.a", ":libcrypto.a"],
             "platforms": ["linux"]
         }
     ],


### PR DESCRIPTION
In the last MR the `staticssl` configuration also set the `-static` dflag. However, this forces dependent application to be fully statically linked.

Sometimes one just wants to link openssl statically while keeping e.g. libc dynamic (it is way more stable).

This MR removes the `-static` dflag so it doesn't force apps to use it, subsequently it changes the ssl and crypto library files to static ones (otherwise its going to pick the dynamic .so files).

This allows the final application to choose whether to link fully statically or not.

Sorry for the quick addendum.