### PR TITLE
Load OpenSSL 3.x dlls in Windows

### DIFF
--- a/source/requests/ssl_adapter.d
+++ b/source/requests/ssl_adapter.d
@@ -121,11 +121,15 @@ shared static this() {
              "libssl32.dll"w,
              "libssl-1_1"w,
              "libssl-1_1-x64"w,
+             "libssl-3"w,
+             "libssl-3-x64"w,
          ];
          immutable wstring[] libcryptoname = [
              "libeay32.dll"w,
              "libcrypto-1_1"w,
              "libcrypto-1_1-x64"w,
+             "libcrypto-3"w,
+             "libcrypto-3-x64"w,
         ];
     } else {
         debug(requests) trace("error loading openssl: unsupported system - first access over https will fail");


### PR DESCRIPTION
`ssl_adapter.d` only attempts to load the old `libssl32.dll` and OpenSSL 1.1 dlls (`libssl-1_1` and `libssl-1_1-x64`).

As such OpenSSL 3.0 doesn't work.

https://github.com/ikod/dlang-requests/blob/b09d5fd5e03d6cba17edfbbd6d55abdb9c7402d0/source/requests/ssl_adapter.d#L118-L129

This just adds `libssl-3` and `libssl-3-x64` to the list.

Tested with OpenSSL 3.2.0 and 3.1.4 [from slproweb.com](https://slproweb.com/products/Win32OpenSSL.html) on Windows 64-bit, but I don't see why it wouldn't work on 32-bit.