### PR TITLE
Phobos url encoding

### DIFF
--- a/source/requests/http.d
+++ b/source/requests/http.d
@@ -419,8 +419,9 @@ public struct HTTPRequest {
     /// encode parameters and build query part of the url
     ///
     private static string params2query(in QueryParam[] params) pure @safe {
+        import std.uri: encodeComponent;
         return params.
-                map!(a => "%s=%s".format(a.key.urlEncoded, a.value.urlEncoded)).
+                map!(a => "%s=%s".format(a.key.encodeComponent, a.value.encodeComponent)).
                 join("&");
     }
     //

--- a/source/requests/utils.d
+++ b/source/requests/utils.d
@@ -193,6 +193,7 @@ string urlDecode(string p) {
 
 package unittest {
     assert(urlDecode("a+bc%20%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D") == `a bc !#$&'()*+,/:;=?@[]`);
+    assert(urlDecode("%E0%B6%9E") == `ඞ`);
 }
 
 

--- a/source/requests/utils.d
+++ b/source/requests/utils.d
@@ -159,19 +159,6 @@ string[] dump(in ubyte[] data) {
     return res;
 }
 
-static string urlEncoded(string p) pure @safe {
-    immutable string[dchar] translationTable = [
-        ' ':  "%20", '!': "%21", '*': "%2A", '\'': "%27", '(': "%28", ')': "%29",
-        ';':  "%3B", ':': "%3A", '@': "%40", '&':  "%26", '=': "%3D", '+': "%2B",
-        '$':  "%24", ',': "%2C", '/': "%2F", '?':  "%3F", '#': "%23", '[': "%5B",
-        ']':  "%5D", '%': "%25",
-    ];
-    return p.translate(translationTable);
-}
-package unittest {
-    assert(urlEncoded(`abc !#$&'()*+,/:;=?@[]`) == "abc%20%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D");
-}
-
 private static immutable char[string] hex2chr;
 shared static this() {
     foreach(c; 0..255) {
@@ -205,7 +192,6 @@ string urlDecode(string p) {
 }
 
 package unittest {
-    assert(urlEncoded(`abc !#$&'()*+,/:;=?@[]`) == "abc%20%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D");
     assert(urlDecode("a+bc%20%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D") == `a bc !#$&'()*+,/:;=?@[]`);
 }
 


### PR DESCRIPTION
Fix https://github.com/ikod/dlang-requests/issues/173: URL Encoding of QueryParams broken for non-ascii characters

urlEncoded used a table based approach, but it can't enumerate almost
every unicode symbol, so the dynamic approach that phobos uses is more
suited here.

Important difference: phobos encodeComponent doesn't encode parentheses.
It is optional to percent-encode them in the query, but this might be
considered a breaking change.

From the RFC3986 grammar:
```
   pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
   query         = *( pchar / "/" / "?" )
```